### PR TITLE
Upgrade libgnome-keyring and change StartupWMClass

### DIFF
--- a/apply_extra
+++ b/apply_extra
@@ -7,6 +7,6 @@ mv usr/* .
 rmdir usr
 mkdir -p export/share/applications
 sed -e 's/Icon=skypeforlinux/Icon=com.skype.Client/' -e 's/\/usr\/bin\/skypeforlinux/\/app\/bin\/skype/' share/applications/skypeforlinux.desktop > export/share/applications/com.skype.Client.desktop
-echo StartupWMClass=Skype >> export/share/applications/com.skype.Client.desktop
+echo StartupWMClass=SkypeAlpha >> export/share/applications/com.skype.Client.desktop
 mkdir -p export/share/icons/hicolor/256x256/apps
 cp share/icons/hicolor/256x256/apps/skypeforlinux.png export/share/icons/hicolor/256x256/apps/com.skype.Client.png

--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -147,8 +147,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgnome-keyring/2.32/libgnome-keyring-2.32.0.tar.gz",
-                    "sha256": "0f6e485ce26cdee1f3e24c994815628677d20b1946fbe7997a38bf83c3133862"
+                    "url": "https://download.gnome.org/sources/libgnome-keyring/3.12/libgnome-keyring-3.12.0.tar.xz",
+                    "sha256": "c4c178fbb05f72acc484d22ddb0568f7532c409b0a13e06513ff54b91e947783"
                 }
             ]
         },


### PR DESCRIPTION
It seems an old libgnome-keyring was used, updated
it to latest. That fixed an issue with credentials
not being remembered.

Avoid conflicting StartupWMClass with
the regular skype client, by changing the
StartupWMClass to SkypeAlpha