### PR TITLE
Use libsecret instead of gnome-keyring

### DIFF
--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -141,7 +141,7 @@
             ]
         },
         {
-            "name": "libgnome-keyring",
+            "name": "libsecret",
             "config-opts": ["--disable-gtk-doc",
                             "--enable-introspection=no",
                             "--disable-man",
@@ -149,8 +149,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgnome-keyring/3.12/libgnome-keyring-3.12.0.tar.xz",
-                    "sha256": "c4c178fbb05f72acc484d22ddb0568f7532c409b0a13e06513ff54b91e947783"
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/libsecret/0.18/libsecret-0.18.5.tar.xz",
+                    "sha256": "9ce7bd8dd5831f2786c935d82638ac428fa085057cc6780aba0e39375887ccb3"
                 }
             ]
         },


### PR DESCRIPTION
In version 5.3 skype switched from gnome-keyring
to libsecret. So this is just to reflect that and
make credentials work again.